### PR TITLE
Fix workflow execution step-through and resume functionality

### DIFF
--- a/src/components/developer/workflow-editor/execution-controls.tsx
+++ b/src/components/developer/workflow-editor/execution-controls.tsx
@@ -65,7 +65,7 @@ export function ExecutionControls({
     if (!engine) return;
 
     if (executionState?.status === 'paused') {
-      engine.resume();
+      await engine.resume();
     } else {
       await engine.execute({ mode: executionMode });
     }
@@ -81,7 +81,14 @@ export function ExecutionControls({
 
   const handleStep = async () => {
     if (!engine) return;
-    await engine.execute({ mode: 'step' });
+
+    // If idle or completed, start fresh in step mode
+    if (!executionState || executionState.status === 'idle' || executionState.status === 'completed') {
+      await engine.execute({ mode: 'step' });
+    } else if (executionState.status === 'paused') {
+      // If paused, step forward one node
+      await engine.stepForward();
+    }
   };
 
   const handleReplay = async () => {


### PR DESCRIPTION
## Summary
- Fixed step-through execution not advancing to next node
- Fixed resume button not working properly
- Added proper execution state tracking

## Changes
- Added `lastExecutedNodeIndex` and `executionOrder` to ExecutionState interface for tracking progress
- Made `resume()` method async and ensured it preserves the execution mode (full/step)
- Added `stepForward()` method for proper step-by-step execution
- Updated ExecutionControls component to properly await async resume
- Enhanced step button to intelligently handle both initial and paused states

## Problem Solved
Previously, when using step-through execution mode:
1. The workflow would execute the first node but wouldn't advance when clicking "Step" again
2. The resume button would not properly continue execution from a paused state
3. Execution state wasn't properly tracked between pause/resume cycles

## Testing
The workflow execution engine now properly:
- Steps through nodes one at a time when in step mode
- Resumes from the correct position when paused
- Tracks execution progress accurately
- Maintains execution mode (full/step) when resuming

🤖 Generated with [Claude Code](https://claude.com/claude-code)