### PR TITLE
Fix CORS issue with HTTP requests in workflow execution

### DIFF
--- a/src/app/api/developer/workflows/proxy/route.ts
+++ b/src/app/api/developer/workflows/proxy/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/core/auth/config';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Check authentication
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { url, method = 'GET', headers = {}, body: requestBody } = body;
+
+    if (!url) {
+      return NextResponse.json({ error: 'URL is required' }, { status: 400 });
+    }
+
+    // Prepare fetch options
+    const fetchOptions: RequestInit = {
+      method,
+      headers: {
+        ...headers,
+        // Remove headers that might cause issues
+        'host': undefined,
+        'origin': undefined,
+        'referer': undefined,
+      },
+    };
+
+    // Add body for POST/PUT/PATCH requests
+    if (['POST', 'PUT', 'PATCH'].includes(method) && requestBody) {
+      fetchOptions.body = typeof requestBody === 'string'
+        ? requestBody
+        : JSON.stringify(requestBody);
+
+      // Set content-type if not already set
+      if (!fetchOptions.headers['content-type'] && !fetchOptions.headers['Content-Type']) {
+        fetchOptions.headers['Content-Type'] = 'application/json';
+      }
+    }
+
+    console.log(`Proxying ${method} request to ${url}`);
+
+    // Make the actual request
+    const response = await fetch(url, fetchOptions);
+
+    // Get response data
+    let data;
+    const contentType = response.headers.get('content-type');
+
+    if (contentType && contentType.includes('application/json')) {
+      data = await response.json();
+    } else if (contentType && contentType.includes('text')) {
+      data = await response.text();
+    } else {
+      // For binary data, convert to base64
+      const buffer = await response.arrayBuffer();
+      data = {
+        type: 'binary',
+        contentType,
+        size: buffer.byteLength,
+        base64: Buffer.from(buffer).toString('base64')
+      };
+    }
+
+    // Return the proxied response
+    return NextResponse.json({
+      url,
+      method,
+      status: response.status,
+      statusText: response.statusText,
+      headers: Object.fromEntries(response.headers.entries()),
+      data,
+      success: response.ok,
+    });
+
+  } catch (error: any) {
+    console.error('Proxy request failed:', error);
+    return NextResponse.json({
+      error: error.message || 'Proxy request failed',
+      success: false,
+    }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
Fixed the "Failed to fetch" error when executing HTTP request nodes in workflows by implementing a server-side proxy.

## Problem
When executing an HTTP request node in the workflow, the browser was throwing:
```
Console TypeError: Failed to fetch
at WorkflowExecutionEngine.executeActionNode (src/core/workflow/execution-engine.ts:301:34)
```

This was due to CORS (Cross-Origin Resource Sharing) restrictions - browsers block direct fetch requests to external domains that don't have proper CORS headers.

## Solution
1. **Created API Proxy Endpoint** (`/api/developer/workflows/proxy`):
   - Handles authentication to ensure only logged-in users can use it
   - Forwards HTTP requests from the server side (no CORS restrictions)
   - Supports all HTTP methods (GET, POST, PUT, PATCH, DELETE)
   - Handles JSON, text, and binary responses
   - Preserves headers and request bodies

2. **Updated Execution Engine**:
   - Routes all HTTP requests through the proxy endpoint
   - Maintains the same interface and response format
   - Adds proper error handling for proxy failures

## Testing
Now when you:
1. Add a Manual Trigger node
2. Connect it to an HTTP Request node
3. Configure the HTTP request (any external URL)
4. Click "Run"

The HTTP request will successfully execute through the proxy, avoiding CORS issues entirely.

## Security
- Proxy endpoint requires authentication
- Only processes requests from authenticated users
- Strips potentially problematic headers (host, origin, referer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)